### PR TITLE
Bump activesupport from 6.0.2.2 to 7.x

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     polygonio (0.2.4)
-      activesupport (~> 6.0, >= 6.0.2.2)
+      activesupport (>= 6.0.2.2, < 8)
       dry-struct (~> 1.2, >= 1.2.0)
       dry-types (~> 1.2, >= 1.2.2)
       eventmachine (~> 1.2, >= 1.2.7)
@@ -16,17 +16,16 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (6.1.0)
+    activesupport (7.0.4.1)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 1.6, < 2)
       minitest (>= 5.1)
       tzinfo (~> 2.0)
-      zeitwerk (~> 2.3)
     ast (2.4.0)
     bundler-audit (0.6.1)
       bundler (>= 1.2.0, < 3)
       thor (~> 0.18)
-    concurrent-ruby (1.1.6)
+    concurrent-ruby (1.1.10)
     dotenv (2.7.5)
     dry-configurable (0.12.0)
       concurrent-ruby (~> 1.0)
@@ -64,7 +63,7 @@ GEM
       faraday (~> 0.9)
       faraday_middleware (>= 0.9.1, < 1.0)
       oj (>= 2.0, < 4.0)
-    i18n (1.8.2)
+    i18n (1.12.0)
       concurrent-ruby (~> 1.0)
     ice_nine (0.11.2)
     jaro_winkler (1.5.4)
@@ -90,14 +89,13 @@ GEM
       rubocop (>= 0.71.0)
     ruby-progressbar (1.10.1)
     thor (0.20.3)
-    tzinfo (2.0.4)
+    tzinfo (2.0.5)
       concurrent-ruby (~> 1.0)
     unicode-display_width (1.6.1)
     vcr (5.1.0)
     websocket-driver (0.7.3)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
-    zeitwerk (2.4.2)
 
 PLATFORMS
   ruby

--- a/polygonio.gemspec
+++ b/polygonio.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency "activesupport", ["~> 6.0", ">= 6.0.2.2"]
+  spec.add_runtime_dependency "activesupport", ">= 6.0.2.2", "< 8"
   spec.add_runtime_dependency "dry-struct", ["~> 1.2", ">= 1.2.0"]
   spec.add_runtime_dependency "dry-types", ["~> 1.2", ">= 1.2.2"]
   spec.add_runtime_dependency "eventmachine", ["~> 1.2", ">= 1.2.7"]


### PR DESCRIPTION
…2, < 8

Updates the requirements on [activesupport](https://github.com/rails/rails) to permit the latest version.
- [Release notes](https://github.com/rails/rails/releases)
- [Changelog](https://github.com/rails/rails/blob/v7.0.4.1/activesupport/CHANGELOG.md)
- [Commits](https://github.com/rails/rails/compare/v6.1.0...v7.0.4.1)

---
updated-dependencies:
- dependency-name: activesupport dependency-type: direct:production ...